### PR TITLE
Feat: add support for Docker secrets for UOS_SYSTEM_IP

### DIFF
--- a/uos-entrypoint.sh
+++ b/uos-entrypoint.sh
@@ -103,16 +103,22 @@ if { [ -f "$SYS_VENDOR" ] && grep -q "Synology" "$SYS_VENDOR"; } \
 fi
 
 # Set UOS_SYSTEM_IP
+if [ -n "$UOS_SYSTEM_IP_FILE" ] && [ -f "$UOS_SYSTEM_IP_FILE" ]; then
+    UOS_SYSTEM_IP_VALUE=$(< "$UOS_SYSTEM_IP_FILE")
+elif [ -n "${UOS_SYSTEM_IP+1}" ]; then
+    UOS_SYSTEM_IP_VALUE="$UOS_SYSTEM_IP"
+fi
+
 UNIFI_SYSTEM_PROPERTIES="/var/lib/unifi/system.properties"
-if [ -n "${UOS_SYSTEM_IP+1}" ]; then
-    echo "Setting UOS_SYSTEM_IP to $UOS_SYSTEM_IP"
+if [ -n "${UOS_SYSTEM_IP_VALUE+1}" ]; then
+    echo "Setting UOS_SYSTEM_IP to $UOS_SYSTEM_IP_VALUE"
     if [ ! -f "$UNIFI_SYSTEM_PROPERTIES" ]; then
-        echo "system_ip=$UOS_SYSTEM_IP" >> "$UNIFI_SYSTEM_PROPERTIES"
+        echo "system_ip=$UOS_SYSTEM_IP_VALUE" >> "$UNIFI_SYSTEM_PROPERTIES"
     else
         if grep -q "^system_ip=.*" "$UNIFI_SYSTEM_PROPERTIES"; then
-            sed -i 's/^system_ip=.*/system_ip='"$UOS_SYSTEM_IP"'/' "$UNIFI_SYSTEM_PROPERTIES"
+            sed -i 's/^system_ip=.*/system_ip='"$UOS_SYSTEM_IP_VALUE"'/' "$UNIFI_SYSTEM_PROPERTIES"
         else
-            echo "system_ip=$UOS_SYSTEM_IP" >> "$UNIFI_SYSTEM_PROPERTIES"
+            echo "system_ip=$UOS_SYSTEM_IP_VALUE" >> "$UNIFI_SYSTEM_PROPERTIES"
         fi
     fi
 fi


### PR DESCRIPTION
The entrypoint now checks first if `UOS_SYSTEM_IP_FILE` is set and points to an existing file. If so, the value is read from that file. Otherwise, it falls back to the existing `UOS_SYSTEM_IP` environment variable.

In a `docker-compose.yml`, you can use it as follows:

```
---
services:
  unifi-os-server:
    ...
    environment:
      - UOS_SYSTEM_IP_FILE=/run/secrets/address
    secrets:
      - address

secrets:
  address:
    file: /path/to/file
```