### PR TITLE
Fix lingering systemd-shutdown process on container stop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ghcr.io/lemker/uosserver:f77bca81ecbf-multiarch
 
 LABEL org.opencontainers.image.source="https://github.com/lemker/unifi-os-server"
 
+ENV container=docker
 ENV APP_VERSION="5.1.15"
 ENV APP_MODEL="UOSSERVER"
 ENV PRODUCT_NAME="UniFi OS Server"


### PR DESCRIPTION
Ordinarily, systemd expects to be able to halt/shutdown the system itself, so the systemd-shutdown process doesn't need to stop itself. But inside a container it can't do that, so it stays running as PID 1 forever causing the container to hang at the stopping stage. Note that although PID 1 hangs, it does already gracefully shut down all the services.

This patch lets systemd know that it's running inside a container, so it will stop itself completely.

Fixes #113 