### PR TITLE
Update ports and environment variables for 5.1.15

### DIFF
--- a/.github/workflows/release-check.yaml
+++ b/.github/workflows/release-check.yaml
@@ -73,10 +73,10 @@ jobs:
             --json number \
             --jq 'length')
           if [ "${pr_count}" -gt 0 ]; then
-            echo "UOS_SERVER_VERSION ${{ env.UOS_VERSION }} already exists!"
+            echo "APP_VERSION ${{ env.UOS_VERSION }} already exists!"
             echo "released=true" >> "$GITHUB_OUTPUT"
           else
-            echo "UOS_SERVER_VERSION ${{ env.UOS_VERSION }} does not exist!"
+            echo "APP_VERSION ${{ env.UOS_VERSION }} does not exist!"
             echo "released=false" >> "$GITHUB_OUTPUT"
           fi
         
@@ -118,7 +118,7 @@ jobs:
       - name: Update Dockerfile
         run: |
           sed -i "s/uosserver:.*/uosserver:$PODMAN_IMAGE_TAG-multiarch/" Dockerfile
-          sed -i "s/UOS_SERVER_VERSION=.*/UOS_SERVER_VERSION=\"$UOS_VERSION\"/" Dockerfile
+          sed -i "s/APP_VERSION=.*/APP_VERSION=\"$UOS_VERSION\"/" Dockerfile
       
       - name: Create pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM ghcr.io/lemker/uosserver:f77bca81ecbf-multiarch
 
 LABEL org.opencontainers.image.source="https://github.com/lemker/unifi-os-server"
 
-ENV UOS_SERVER_VERSION="5.1.15"
+ENV APP_VERSION="5.1.15"
+ENV APP_MODEL="UOSSERVER"
+ENV PRODUCT_NAME="UniFi OS Server"
 
 STOPSIGNAL SIGRTMIN+3
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ tcp:
   9543: "unifi/unifi-os-server-id-hub-svc:9543" # Optional
   6789: "unifi/unifi-os-server-mobile-speedtest-svc:6789" # Optional
   8080: "unifi/unifi-os-server-communication-svc:8080"
-  8443: "unifi/unifi-os-server-network-app-svc:8443" # Optional
   8444: "unifi/unifi-os-server-hotspot-secured-svc:8444" # Optional
-  11084: "unifi/unifi-os-server-site-supervisor-svc:11084" # Optional
+  28082: "unifi/unifi-os-server-support-files:28082" # Optional
   5671: "unifi/unifi-os-server-aqmps-svc:5671" # Optional
   8880: "unifi/unifi-os-server-hotspot-redirect-0-svc:8880" # Optional
   8881: "unifi/unifi-os-server-hotspot-redirect-1-svc:8881" # Optional
@@ -75,12 +74,11 @@ Overrides your detected hardware platform. Accepted values are: `synology`.
 | TCP | 9543 | Ingress | UniFi Identity Hub |
 | TCP | 6789 | Ingress | UniFi mobile speed test |
 | TCP | 8080 | Ingress | Device and application communication |
-| TCP | 8443 | Ingress | UniFi Network Application GUI/API |
 | TCP | 8444 | Ingress | Secure Portal for Hotspot |
 | UDP | 3478 | Both | STUN for device adoption and communication *(also required for Remote Management)* |
 | UDP | 5514 | Ingress | Remote syslog capture |
 | UDP | 10003 | Ingress | Device discovery during adoption |
-| TCP | 11084 | Ingress | UniFi Site Supervisor |
+| TCP | 28082 | Ingress | Device support files download |
 | TCP | 5671 | Ingress | AQMPS |
 | TCP | 8880 | Ingress | Hotspot portal redirection (HTTP) |
 | TCP | 8881 | Ingress | Hotspot portal redirection (HTTP) |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,12 +32,11 @@ services:
       - 9543:9543 # Optional
       - 6789:6789 # Optional
       - 8080:8080
-      - 8443:8443 # Optional
       - 8444:8444 # Optional
       - 3478:3478/udp
       - 5514:5514/udp # Optional
       - 10003:10003/udp
-      - 11084:11084 # Optional
+      - 127.0.0.1:11084:11084 # Optional
       - 5671:5671 # Optional
       - 8880:8880 # Optional
       - 8881:8881 # Optional

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -17,53 +17,57 @@ spec:
         app: unifi-os-server
     spec:
       containers:
-      - name: unifi-os-server
-        image: ghcr.io/lemker/unifi-os-server:latest
-        env:
-        - name: HOST_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: UOS_SYSTEM_IP
-          value: "unifi.example.com"
-        securityContext:
-          privileged: true
-        lifecycle:
-          postStart:
-            exec:
-              command: ["/bin/bash", "-c", "echo $HOST_IP host.docker.internal >> /etc/hosts"]
-        volumeMounts:
-        - name: unifi-os-server-data
-          mountPath: /persistent
-          subPath: persistent
-        - name: unifi-os-server-data
-          mountPath: /var/log
-          subPath: log
-        - name: unifi-os-server-data
-          mountPath: /data
-          subPath: data
-        - name: unifi-os-server-data
-          mountPath: /srv
-          subPath: srv
-        - name: unifi-os-server-data
-          mountPath: /var/lib/unifi
-          subPath: unifi
-        - name: unifi-os-server-data
-          mountPath: /var/lib/mongodb
-          subPath: mongodb
-        - name: unifi-os-server-data
-          mountPath: /etc/rabbitmq/ssl
-          subPath: rabbitmq
-        livenessProbe:
-          httpGet:
-            path: /api/ping
-            port: 80
-          initialDelaySeconds: 10          
-          periodSeconds: 60
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 3
+        - name: unifi-os-server
+          image: ghcr.io/lemker/unifi-os-server:latest
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: UOS_SYSTEM_IP
+              value: "unifi.example.com"
+          securityContext:
+            privileged: true
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/bash", "-c", "echo $HOST_IP host.docker.internal >> /etc/hosts"]
+          volumeMounts:
+            - name: unifi-os-server-data
+              mountPath: /persistent
+              subPath: persistent
+            - name: unifi-os-server-data
+              mountPath: /var/log
+              subPath: log
+            - name: unifi-os-server-data
+              mountPath: /data
+              subPath: data
+            - name: unifi-os-server-data
+              mountPath: /srv
+              subPath: srv
+            - name: unifi-os-server-data
+              mountPath: /var/lib/unifi
+              subPath: unifi
+            - name: unifi-os-server-data
+              mountPath: /var/lib/mongodb
+              subPath: mongodb
+            - name: unifi-os-server-data
+              mountPath: /etc/rabbitmq/ssl
+              subPath: rabbitmq
+          ports:
+            - containerPort: 11084
+              hostPort: 11084
+              hostIP: 127.0.0.1
+          livenessProbe:
+            httpGet:
+              path: /api/ping
+              port: 80
+            initialDelaySeconds: 10          
+            periodSeconds: 60
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
       volumes:
-      - name: unifi-os-server-data
-        persistentVolumeClaim:
-          claimName: unifi-os-server-pvc
+        - name: unifi-os-server-data
+          persistentVolumeClaim:
+            claimName: unifi-os-server-pvc

--- a/kubernetes/ingress.yaml
+++ b/kubernetes/ingress.yaml
@@ -9,16 +9,16 @@ spec:
   ingressClassName: nginx
   tls:
   - hosts:
-    - "unifi.example.com"
+      - "unifi.example.com"
     secretName: tls-secret
   rules:
-  - host: unifi.example.com
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: unifi-os-server-webui-svc
-            port:
-              number: 443
+    - host: unifi.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: unifi-os-server-webui-svc
+                port:
+                  number: 443

--- a/kubernetes/service.yaml
+++ b/kubernetes/service.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: unifi
 spec:
   ports:
-  - name: webui
-    port: 443
-    protocol: TCP
-    targetPort: 443
+    - name: webui
+      port: 443
+      protocol: TCP
+      targetPort: 443
   selector:
     app: unifi-os-server
 
@@ -20,10 +20,10 @@ metadata:
   namespace: unifi
 spec:
   ports:
-  - name: rtp
-    port: 5005
-    protocol: TCP
-    targetPort: 5005
+    - name: rtp
+      port: 5005
+      protocol: TCP
+      targetPort: 5005
   selector:
     app: unifi-os-server
 
@@ -35,10 +35,10 @@ metadata:
   namespace: unifi
 spec:
   ports:
-  - name: id-hub
-    port: 9543
-    protocol: TCP
-    targetPort: 9543
+    - name: id-hub
+      port: 9543
+      protocol: TCP
+      targetPort: 9543
   selector:
     app: unifi-os-server
 
@@ -50,10 +50,10 @@ metadata:
   namespace: unifi
 spec:
   ports:
-  - name: mobile-speedtest
-    port: 6789
-    protocol: TCP
-    targetPort: 6789
+    - name: mobile-speedtest
+      port: 6789
+      protocol: TCP
+      targetPort: 6789
   selector:
     app: unifi-os-server
 
@@ -65,25 +65,10 @@ metadata:
   namespace: unifi
 spec:
   ports:
-  - name: communication
-    port: 8080
-    protocol: TCP
-    targetPort: 8080
-  selector:
-    app: unifi-os-server
-
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: unifi-os-server-network-app-svc
-  namespace: unifi
-spec:
-  ports:
-  - name: network-app
-    port: 8443
-    protocol: TCP
-    targetPort: 8443
+    - name: communication
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
   selector:
     app: unifi-os-server
 
@@ -95,10 +80,10 @@ metadata:
   namespace: unifi
 spec:
   ports:
-  - name: hotspot-secured
-    port: 8444
-    protocol: TCP
-    targetPort: 8444
+    - name: hotspot-secured
+      port: 8444
+      protocol: TCP
+      targetPort: 8444
   selector:
     app: unifi-os-server
 
@@ -110,10 +95,10 @@ metadata:
   namespace: unifi
 spec:
   ports:
-  - name: stun
-    port: 3478
-    protocol: UDP
-    targetPort: 3478
+    - name: stun
+      port: 3478
+      protocol: UDP
+      targetPort: 3478
   selector:
     app: unifi-os-server
 
@@ -125,10 +110,10 @@ metadata:
   namespace: unifi
 spec:
   ports:
-  - name: syslog
-    port: 5514
-    protocol: UDP
-    targetPort: 5514
+    - name: syslog
+      port: 5514
+      protocol: UDP
+      targetPort: 5514
   selector:
     app: unifi-os-server
 
@@ -140,10 +125,10 @@ metadata:
   namespace: unifi
 spec:
   ports:
-  - name: discovery
-    port: 10003
-    protocol: UDP
-    targetPort: 10003
+    - name: discovery
+      port: 10003
+      protocol: UDP
+      targetPort: 10003
   selector:
     app: unifi-os-server
 
@@ -151,14 +136,14 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: unifi-os-server-site-supervisor-svc
+  name: unifi-os-server-support-files-svc
   namespace: unifi
 spec:
   ports:
-  - name: site-supervisor
-    port: 11084
-    protocol: TCP
-    targetPort: 11084
+    - name: support-files
+      port: 28082
+      protocol: TCP
+      targetPort: 28082
   selector:
     app: unifi-os-server
 
@@ -170,10 +155,10 @@ metadata:
   namespace: unifi
 spec:
   ports:
-  - name: aqmps
-    port: 5671
-    protocol: TCP
-    targetPort: 5671
+    - name: aqmps
+      port: 5671
+      protocol: TCP
+      targetPort: 5671
   selector:
     app: unifi-os-server
 
@@ -185,10 +170,10 @@ metadata:
   namespace: unifi
 spec:
   ports:
-  - name: hotspot-redirect-0
-    port: 8880
-    protocol: TCP
-    targetPort: 8880
+    - name: hotspot-redirect-0
+      port: 8880
+      protocol: TCP
+      targetPort: 8880
   selector:
     app: unifi-os-server
 
@@ -200,10 +185,10 @@ metadata:
   namespace: unifi
 spec:
   ports:
-  - name: hotspot-redirect-1
-    port: 8881
-    protocol: TCP
-    targetPort: 8881
+    - name: hotspot-redirect-1
+      port: 8881
+      protocol: TCP
+      targetPort: 8881
   selector:
     app: unifi-os-server
 
@@ -215,9 +200,9 @@ metadata:
   namespace: unifi
 spec:
   ports:
-  - name: hotspot-redirect-2
-    port: 8882
-    protocol: TCP
-    targetPort: 8882
+    - name: hotspot-redirect-2
+      port: 8882
+      protocol: TCP
+      targetPort: 8882
   selector:
     app: unifi-os-server

--- a/uos-entrypoint.sh
+++ b/uos-entrypoint.sh
@@ -26,15 +26,15 @@ else
     exit 1
 fi
 
+echo "Setting APP_MODEL to $APP_MODEL"
+echo "Setting APP_VERSION to $APP_VERSION"
+echo "Setting FIRMWARE_PLATFORM to $FIRMWARE_PLATFORM"
+echo "Setting PRODUCT_NAME to $PRODUCT_NAME"
+
 # Read version from package.json and write version string
 echo "$APP_MODEL.0000000.$APP_VERSION.0000000.000000.0000" > /usr/lib/version
 echo "$FIRMWARE_PLATFORM" > /usr/lib/platform
 echo "$PRODUCT_NAME" > /usr/lib/product_name
-
-echo "Set APP_MODEL to $APP_MODEL"
-echo "Set APP_VERSION to $APP_VERSION"
-echo "Set FIRMWARE_PLATFORM to $FIRMWARE_PLATFORM"
-echo "Set PRODUCT_NAME to $PRODUCT_NAME"
 
 # Create eth0 alias to tap0 (requires NET_ADMIN cap & macvlan kernel module loaded on host) 
 if [ ! -d "/sys/devices/virtual/net/eth0" ] && [ -d "/sys/devices/virtual/net/tap0" ]; then

--- a/uos-entrypoint.sh
+++ b/uos-entrypoint.sh
@@ -16,10 +16,6 @@ if [ ! -f /data/uos_uuid ]; then
     fi
 fi
 
-# Read version from package.json and write version string
-echo "Setting UOS_SERVER_VERSION to $UOS_SERVER_VERSION"
-echo "UOSSERVER.0000000.$UOS_SERVER_VERSION.0000000.000000.0000" > /usr/lib/version
-
 ARCH="$(dpkg --print-architecture)"
 if [ "$ARCH" == "amd64" ]; then
     FIRMWARE_PLATFORM=linux-x64
@@ -30,8 +26,15 @@ else
     exit 1
 fi
 
-echo "Setting FIRMWARE_PLATFORM to $FIRMWARE_PLATFORM"
+# Read version from package.json and write version string
+echo "$APP_MODEL.0000000.$APP_VERSION.0000000.000000.0000" > /usr/lib/version
 echo "$FIRMWARE_PLATFORM" > /usr/lib/platform
+echo "$PRODUCT_NAME" > /usr/lib/product_name
+
+echo "Set APP_MODEL to $APP_MODEL"
+echo "Set APP_VERSION to $APP_VERSION"
+echo "Set FIRMWARE_PLATFORM to $FIRMWARE_PLATFORM"
+echo "Set PRODUCT_NAME to $PRODUCT_NAME"
 
 # Create eth0 alias to tap0 (requires NET_ADMIN cap & macvlan kernel module loaded on host) 
 if [ ! -d "/sys/devices/virtual/net/eth0" ] && [ -d "/sys/devices/virtual/net/tap0" ]; then


### PR DESCRIPTION
See upstream [release notes](https://community.ui.com/releases/UniFi-OS-Server-5-1-15/11843c60-7c4f-4263-9773-4c3df7168d07).

- Removed unused external port 8443
- Restricted port 11084 to loopback access
- Added port 28082 for downloading device support files via the side panel
- Updated environment variables for `APP_MODEL`, `APP_VERSION`, and `PRODUCT_NAME`