### PR TITLE
Support Podman's automatic systemd detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,4 @@ COPY uos-entrypoint.sh /root/uos-entrypoint.sh
 
 RUN ["chmod", "+x", "/root/uos-entrypoint.sh"]
 ENTRYPOINT ["/root/uos-entrypoint.sh"]
+CMD ["/sbin/init"]

--- a/podman-compose.yaml
+++ b/podman-compose.yaml
@@ -1,0 +1,41 @@
+---
+services:
+  unifi-os-server:
+    # Podman automatically detects that the container starts systemd,
+    # so the cgroup line, some of the tmpfs mounts, and the
+    # cgroupfs mount are not necessary
+    image: ghcr.io/lemker/unifi-os-server:latest
+    container_name: unifi-os-server
+    cap_add:
+      - NET_RAW
+      - NET_ADMIN
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    tmpfs:
+      - /var/opt/unifi/tmp:size=64m
+    environment:
+      - UOS_SYSTEM_IP=unifi.example.com
+    volumes:
+      - /path/to/unifi-os-server/persistent:/persistent
+      - /path/to/unifi-os-server/var-log:/var/log
+      - /path/to/unifi-os-server/data:/data
+      - /path/to/unifi-os-server/srv:/srv
+      - /path/to/unifi-os-server/var-lib-unifi:/var/lib/unifi
+      - /path/to/unifi-os-server/var-lib-mongodb:/var/lib/mongodb
+      - /path/to/unifi-os-server/etc-rabbitmq-ssl:/etc/rabbitmq/ssl
+    ports:
+      - 11443:443
+      - 5005:5005 # Optional
+      - 9543:9543 # Optional
+      - 6789:6789 # Optional
+      - 8080:8080
+      - 8444:8444 # Optional
+      - 3478:3478/udp
+      - 5514:5514/udp # Optional
+      - 10003:10003/udp
+      - 127.0.0.1:11084:11084 # Optional
+      - 5671:5671 # Optional
+      - 8880:8880 # Optional
+      - 8881:8881 # Optional
+      - 8882:8882 # Optional
+    restart: unless-stopped

--- a/uos-entrypoint.sh
+++ b/uos-entrypoint.sh
@@ -120,5 +120,8 @@ if [ -n "${UOS_SYSTEM_IP+1}" ]; then
     fi
 fi
 
-# Start systemd
-exec /sbin/init
+# Start systemd or provided container run command
+if [ $# -eq 0 ]; then
+    set -- /sbin/init
+fi
+exec "$@"


### PR DESCRIPTION
Add `CMD ["/sbin/init"]` to the Dockerfile so that [Podman can automatically detect that this container runs systemd](https://www.mankier.com/1/podman-run#Options---systemd=true_%7C_false_%7C_always) (see also https://github.com/podman-container-tools/podman/blob/5b263b5f5b48004a87caac44e67349a8266d9ef4/pkg/specgen/generate/container_create.go#L398-L421). Podman automatically mounts cgroupfs and systemd's needed tmpfs mounts, so also provide a Podman-specific `podman-compose.yaml` file.